### PR TITLE
Migrate to Swift 6 language mode with Swift Testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,13 +14,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  library:
+  test:
     runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.3.app
-        
+
       - name: Run tests
         run: make test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,15 +16,11 @@ concurrency:
 jobs:
   library:
     runs-on: macos-15
-    strategy:
-      matrix:
-        xcode:
-          - '26.4'
 
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
         
       - name: Run tests
         run: make test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,15 +15,16 @@ concurrency:
 
 jobs:
   library:
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       matrix:
         xcode:
-          - '15.4'
+          - '26.4'
 
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+        
       - name: Run tests
         run: make test

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -8,13 +8,13 @@ on:
 jobs:
   swift_format:
     name: swift-format
-    runs-on: macOS-14
+    runs-on: macOS-15
     steps:
       - uses: actions/checkout@v4
-      - name: Xcode Select
-        run: sudo xcode-select -s /Applications/Xcode_15.4.app
+
       - name: Install
         run: brew install swift-format
+        
       - name: Format
         run: make format
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLATFORM_IOS = iOS Simulator,id=$(call udid_for,iOS 17.5,iPhone \d\+ Pro [^M])
+PLATFORM_IOS = iOS Simulator,id=$(call udid_for,iPhone)
 
 default: test
 

--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,5 @@ format:
 		./Examples ./Package.swift ./Sources ./Tests
 
 define udid_for
-$(shell xcrun simctl list devices available '$(1)' | grep '$(2)' | sort -r | head -1 | awk -F '[()]' '{ print $$(NF-3) }')
+$(shell xcrun simctl list --json devices available '$(1)' | jq -r '[.devices|to_entries|sort_by(.key)|reverse|.[].value|select(length > 0)|.[0]][0].udid')
 endef

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.2
 import PackageDescription
 
 let package = Package(
   name: "Pagination",
   platforms: [
-    .iOS(.v12)
+    .iOS(.v13)
   ],
   products: [
     .library(
@@ -15,11 +15,17 @@ let package = Package(
   targets: [
     .target(
       name: "Pagination",
-      path: "Sources/Pagination"
+      path: "Sources/Pagination",
+      swiftSettings: [
+        .swiftLanguageMode(.v6),
+      ]
     ),
     .testTarget(
       name: "PaginationTests",
-      dependencies: ["Pagination"]
+      dependencies: ["Pagination"],
+      swiftSettings: [
+        .swiftLanguageMode(.v6),
+      ]
     ),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -15,17 +15,11 @@ let package = Package(
   targets: [
     .target(
       name: "Pagination",
-      path: "Sources/Pagination",
-      swiftSettings: [
-        .swiftLanguageMode(.v6),
-      ]
+      path: "Sources/Pagination"
     ),
     .testTarget(
       name: "PaginationTests",
-      dependencies: ["Pagination"],
-      swiftSettings: [
-        .swiftLanguageMode(.v6),
-      ]
+      dependencies: ["Pagination"]
     ),
   ]
 )

--- a/Sources/Pagination/Pagination.swift
+++ b/Sources/Pagination/Pagination.swift
@@ -122,9 +122,9 @@ import UIKit
       \.contentOffset,
       options: [.old, .new]
     ) { [weak self] scrollView, change in
-      guard let pagination = self else { return }
+      guard let self else { return }
       MainActor.assumeIsolated {
-        pagination.prefetchIfNeeded(
+        prefetchIfNeeded(
           scrollView: scrollView,
           delegate: delegate,
           change: change)

--- a/Sources/Pagination/Pagination.swift
+++ b/Sources/Pagination/Pagination.swift
@@ -1,8 +1,7 @@
-import Foundation
 import UIKit
 
 /// A protocol that defines methods for handling pagination.
-@objc public protocol PaginationDelegate: AnyObject {
+@objc public protocol PaginationDelegate: AnyObject, Sendable {
   /// Called when the pagination has requested the next page of data.
   /// - Parameters:
   ///   - pagination: The pagination instance that requested the next page.
@@ -58,7 +57,8 @@ import UIKit
 /// > Warning: It is mandatory to call `context.finish(_:)` with either `true` or `false` once the data loading is complete, to accurately reflect the pagination state.
 ///
 /// This class provides methods to monitor scroll view events and manage pagination state efficiently.
-@objcMembers open class Pagination: NSObject {
+@MainActor
+@objcMembers public final class Pagination: NSObject {
   /// The scroll view associated with the paginator.
   ///
   /// This scroll view is monitored for scroll events to trigger pagination.
@@ -121,11 +121,14 @@ import UIKit
     observation = scrollView.observe(
       \.contentOffset,
       options: [.old, .new]
-    ) { [unowned self] scrollView, change in
-      prefetchIfNeeded(
-        scrollView: scrollView,
-        delegate: delegate,
-        change: change)
+    ) { [weak self] scrollView, change in
+      guard let pagination = self else { return }
+      MainActor.assumeIsolated {
+        pagination.prefetchIfNeeded(
+          scrollView: scrollView,
+          delegate: delegate,
+          change: change)
+      }
     }
   }
 

--- a/Sources/Pagination/PaginationContext.swift
+++ b/Sources/Pagination/PaginationContext.swift
@@ -3,7 +3,8 @@ import Foundation
 /// A `PaginationContext` is responsible for managing and tracking the state of a pagination operation in a scrollable view.
 ///
 /// This class ensures thread safety and provides methods to control the state of pagination, making it suitable for use in complex, asynchronous operations that require reliable state management.
-@objcMembers public final class PaginationContext: NSObject {
+/// Concurrency safety is enforced via `NSLock`, so it is safe to pass across actors.
+@objcMembers public final class PaginationContext: NSObject, @unchecked Sendable {
 
   /// Represents the various states a pagination context can be in.
   public enum State {

--- a/Sources/Pagination/PaginationContext.swift
+++ b/Sources/Pagination/PaginationContext.swift
@@ -7,7 +7,7 @@ import Foundation
 @objcMembers public final class PaginationContext: NSObject, @unchecked Sendable {
 
   /// Represents the various states a pagination context can be in.
-  public enum State {
+  public enum State: Sendable {
     /// The context is idle, awaiting the start of a pagination operation.
     case idle
     /// The context is currently in the process of fetching new data.

--- a/Sources/Pagination/UIScrollView+Pagination.swift
+++ b/Sources/Pagination/UIScrollView+Pagination.swift
@@ -2,7 +2,7 @@ import ObjectiveC
 import UIKit
 
 /// A key used for associating the `Pagination` instance with a `UIScrollView` object.
-private var paginationKey: UInt8 = 0
+nonisolated(unsafe) private var paginationKey: UInt8 = 0
 /// Extension to add pagination functionality to any UIScrollView or its subclasses.
 ///
 /// This extension allows `UIScrollView`, including subclasses like `UITableView` and `UICollectionView`, to seamlessly integrate with the `Pagination` class, enabling automatic detection and handling of paginated content loading.

--- a/Tests/PaginationTests/Mocks/MockPaginationDelegate.swift
+++ b/Tests/PaginationTests/Mocks/MockPaginationDelegate.swift
@@ -3,7 +3,7 @@ import Dispatch
 @testable import Pagination
 
 final class MockPaginationDelegate: PaginationDelegate {
-  var didPrefetchNextPageCalled = false
+  nonisolated(unsafe) var didPrefetchNextPageCalled = false
 
   func pagination(_ pagination: Pagination, prefetchNextPageWith context: PaginationContext) {
     context.start()

--- a/Tests/PaginationTests/PaginationContextTests.swift
+++ b/Tests/PaginationTests/PaginationContextTests.swift
@@ -1,53 +1,59 @@
-import XCTest
+import Testing
 
 @testable import Pagination
 
-final class PaginationContextTests: XCTestCase {
+@Suite("PaginationContext")
+struct PaginationContextTests {
 
-  func testInitialState() {
+  @Test("Initial state is idle")
+  func initialState() {
     let context = PaginationContext()
-    XCTAssertFalse(context.isFetching)
-    XCTAssertFalse(context.isCancelled)
-    XCTAssertFalse(context.isCompleted)
-    XCTAssertFalse(context.isFailed)
+    #expect(!context.isFetching)
+    #expect(!context.isCancelled)
+    #expect(!context.isCompleted)
+    #expect(!context.isFailed)
   }
 
-  func testStartPrefetching() {
+  @Test("Start transitions to fetching state")
+  func startPrefetching() {
     let context = PaginationContext()
     context.start()
-    XCTAssertTrue(context.isFetching)
-    XCTAssertFalse(context.isCancelled)
-    XCTAssertFalse(context.isCompleted)
-    XCTAssertFalse(context.isFailed)
+    #expect(context.isFetching)
+    #expect(!context.isCancelled)
+    #expect(!context.isCompleted)
+    #expect(!context.isFailed)
   }
 
-  func testCancelPrefetching() {
+  @Test("Cancel transitions to cancelled state")
+  func cancelPrefetching() {
     let context = PaginationContext()
     context.start()
     context.cancel()
-    XCTAssertFalse(context.isFetching)
-    XCTAssertTrue(context.isCancelled)
-    XCTAssertFalse(context.isCompleted)
-    XCTAssertFalse(context.isFailed)
+    #expect(!context.isFetching)
+    #expect(context.isCancelled)
+    #expect(!context.isCompleted)
+    #expect(!context.isFailed)
   }
 
-  func testFinishPrefetchingSuccessfully() {
+  @Test("Finish with true transitions to completed state")
+  func finishPrefetchingSuccessfully() {
     let context = PaginationContext()
     context.start()
     context.finish(true)
-    XCTAssertFalse(context.isFetching)
-    XCTAssertFalse(context.isCancelled)
-    XCTAssertTrue(context.isCompleted)
-    XCTAssertFalse(context.isFailed)
+    #expect(!context.isFetching)
+    #expect(!context.isCancelled)
+    #expect(context.isCompleted)
+    #expect(!context.isFailed)
   }
 
-  func testPrefetchingFailed() {
+  @Test("Finish with false transitions to failed state")
+  func prefetchingFailed() {
     let context = PaginationContext()
     context.start()
     context.finish(false)
-    XCTAssertFalse(context.isFetching)
-    XCTAssertFalse(context.isCancelled)
-    XCTAssertFalse(context.isCompleted)
-    XCTAssertTrue(context.isFailed)
+    #expect(!context.isFetching)
+    #expect(!context.isCancelled)
+    #expect(!context.isCompleted)
+    #expect(context.isFailed)
   }
 }

--- a/Tests/PaginationTests/PaginationDirectionTests.swift
+++ b/Tests/PaginationTests/PaginationDirectionTests.swift
@@ -1,28 +1,31 @@
-import XCTest
+import Testing
 
 @testable import Pagination
 
-final class PaginationDirectionTests: XCTestCase {
+@Suite("PaginationDirection")
+struct PaginationDirectionTests {
 
-  func testVerticalDirection() {
-    let paginationDirection: PaginationDirection = .vertical
-    XCTAssertTrue(paginationDirection.description == "vertical")
-    XCTAssertFalse(paginationDirection.contains(.left))
-    XCTAssertFalse(paginationDirection.contains(.right))
-    XCTAssertFalse(paginationDirection.contains(.horizontal))
-    XCTAssertTrue(paginationDirection.contains(.up))
-    XCTAssertTrue(paginationDirection.contains(.down))
-    XCTAssertTrue(paginationDirection.contains(.vertical))
+  @Test("Vertical direction contains up, down, and vertical")
+  func verticalDirection() {
+    let direction: PaginationDirection = .vertical
+    #expect(direction.description == "vertical")
+    #expect(!direction.contains(.left))
+    #expect(!direction.contains(.right))
+    #expect(!direction.contains(.horizontal))
+    #expect(direction.contains(.up))
+    #expect(direction.contains(.down))
+    #expect(direction.contains(.vertical))
   }
 
-  func testHorzontalDirection() {
-    let paginationDirection: PaginationDirection = .horizontal
-    XCTAssertTrue(paginationDirection.description == "horizontal")
-    XCTAssertTrue(paginationDirection.contains(.left))
-    XCTAssertTrue(paginationDirection.contains(.right))
-    XCTAssertTrue(paginationDirection.contains(.horizontal))
-    XCTAssertFalse(paginationDirection.contains(.up))
-    XCTAssertFalse(paginationDirection.contains(.down))
-    XCTAssertFalse(paginationDirection.contains(.vertical))
+  @Test("Horizontal direction contains left, right, and horizontal")
+  func horizontalDirection() {
+    let direction: PaginationDirection = .horizontal
+    #expect(direction.description == "horizontal")
+    #expect(direction.contains(.left))
+    #expect(direction.contains(.right))
+    #expect(direction.contains(.horizontal))
+    #expect(!direction.contains(.up))
+    #expect(!direction.contains(.down))
+    #expect(!direction.contains(.vertical))
   }
 }

--- a/Tests/PaginationTests/PaginationTests.swift
+++ b/Tests/PaginationTests/PaginationTests.swift
@@ -2,21 +2,8 @@ import XCTest
 
 @testable import Pagination
 
+@MainActor
 final class PaginationTests: XCTestCase {
-
-  var sut: Pagination!
-
-  override func setUp() {
-    super.setUp()
-
-    sut = Pagination()
-  }
-
-  override func tearDown() {
-    super.tearDown()
-
-    sut = nil
-  }
 
   func testScrollViewIntegration() {
     let scrollView = MockScrollView()
@@ -59,6 +46,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testBatchNullState() {
+    let sut = Pagination()
     // Test with default settings
     let context = PaginationContext()
     let shouldFetch = sut.shouldPrefetchNextPage(
@@ -104,6 +92,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testBatchAlreadyFetching() {
+    let sut = Pagination()
     let context = PaginationContext()
     context.start()
     let shouldFetch = sut.shouldPrefetchNextPage(
@@ -154,6 +143,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testIsNotVisible() {
+    let sut = Pagination()
     let context = PaginationContext()
     let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
@@ -203,6 +193,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testScrollDirection() {
+    let sut = Pagination()
     let directionUp = sut.detectScrollDirection(
       oldOffset: .verticalOffset(y: 1),
       newOffset: .zero
@@ -229,6 +220,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testUnsupportedScrollDirections() {
+    let sut = Pagination()
     let context = PaginationContext()
     // Test scrolling right
     let fetchRight = sut.shouldPrefetchNextPage(
@@ -400,6 +392,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testVerticalScrollToExactLeading() {
+    let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
     // Scroll to 1-screen top offset, height is 1 screen, so bottom is 1 screen away from the end of content
@@ -455,6 +448,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testVerticalScrollToLessThanLeading() {
+    let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
     // 3 screens of content, scroll only 1/2 of one screen
@@ -510,6 +504,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testVerticalScrollingPastContentSize() {
+    let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
     // 3 screens of content, top offset to 3-screens, height 1 screen, so it's 1 screen past the leading
@@ -563,6 +558,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testHorizontalScrollToExactLeading() {
+    let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
     // Scroll to 1-screen left offset, width is 1 screen, so right is 1 screen away from end of content
@@ -619,6 +615,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testHorizontalScrollToLessThanLeading() {
+    let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
     // 3 screens of content, scroll only 1/2 of one screen
@@ -675,6 +672,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testHorizontalScrollingPastContentSize() {
+    let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
     // 3 screens of content, offset 3 screens, width 1 screen, so it's 1 screen past the leading
@@ -730,6 +728,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testVerticalScrollingSmallContentSize() {
+    let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
     // When the content size is smaller than the screen size, the target offset will always be 0
@@ -786,6 +785,7 @@ final class PaginationTests: XCTestCase {
   }
 
   func testHorizontalScrollingSmallContentSize() {
+    let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
     // When the content size is smaller than the screen size, the target offset will always be 0

--- a/Tests/PaginationTests/PaginationTests.swift
+++ b/Tests/PaginationTests/PaginationTests.swift
@@ -1,53 +1,62 @@
-import XCTest
+import Testing
+import UIKit
 
 @testable import Pagination
 
+@Suite("Pagination")
 @MainActor
-final class PaginationTests: XCTestCase {
+struct PaginationTests {
 
-  func testScrollViewIntegration() {
+  // MARK: - Integration Tests
+
+  @Test("Scroll view triggers delegate when scrolled past threshold")
+  func scrollViewIntegration() {
     let scrollView = MockScrollView()
     let delegate = MockPaginationDelegate()
-    let screenHeigth: CGFloat = 100
-    scrollView.bounds = .verticalRect(height: screenHeigth)
-    scrollView.contentSize = .verticalSize(height: 3 * screenHeigth)
+    let screenHeight: CGFloat = 100
+    scrollView.bounds = .verticalRect(height: screenHeight)
+    scrollView.contentSize = .verticalSize(height: 3 * screenHeight)
     scrollView.pagination.delegate = delegate
     scrollView.pagination.direction = .vertical
     scrollView.pagination.leadingScreensForPrefetching = 1
-    scrollView.setContentOffset(.verticalOffset(y: screenHeigth * 2.5), animated: false)
-    XCTAssertTrue(delegate.didPrefetchNextPageCalled, "Should call delegate method")
+    scrollView.setContentOffset(.verticalOffset(y: screenHeight * 2.5), animated: false)
+    #expect(delegate.didPrefetchNextPageCalled)
   }
 
-  func testTableViewIntegration() {
+  @Test("Table view triggers delegate when scrolled past threshold")
+  func tableViewIntegration() {
     let tableView = MockTableView()
     let delegate = MockPaginationDelegate()
-    let screenHeigth: CGFloat = 100
-    tableView.bounds = .verticalRect(height: screenHeigth)
-    tableView.contentSize = .verticalSize(height: 3 * screenHeigth)
+    let screenHeight: CGFloat = 100
+    tableView.bounds = .verticalRect(height: screenHeight)
+    tableView.contentSize = .verticalSize(height: 3 * screenHeight)
     tableView.pagination.delegate = delegate
     tableView.pagination.direction = .vertical
     tableView.pagination.leadingScreensForPrefetching = 1
-    tableView.setContentOffset(.verticalOffset(y: screenHeigth * 2), animated: false)
-    XCTAssertTrue(delegate.didPrefetchNextPageCalled, "Should call delegate method")
+    tableView.setContentOffset(.verticalOffset(y: screenHeight * 2), animated: false)
+    #expect(delegate.didPrefetchNextPageCalled)
   }
 
-  func testCollectionViewIntegration() {
-    let screenHeigth: CGFloat = 100
+  @Test("Collection view triggers delegate when scrolled past threshold")
+  func collectionViewIntegration() {
+    let screenHeight: CGFloat = 100
     let collectionView = MockCollectionView(
-      frame: .horizontalRect(width: screenHeigth),
+      frame: .horizontalRect(width: screenHeight),
       collectionViewLayout: MockCollectionViewLayout())
     let delegate = MockPaginationDelegate()
-    collectionView.contentSize = .horizontalSize(width: screenHeigth * 3)
+    collectionView.contentSize = .horizontalSize(width: screenHeight * 3)
     collectionView.pagination.delegate = delegate
     collectionView.pagination.direction = .horizontal
     collectionView.pagination.leadingScreensForPrefetching = 1
-    collectionView.setContentOffset(.horizontalOffset(x: screenHeigth * 2.5), animated: false)
-    XCTAssertTrue(delegate.didPrefetchNextPageCalled, "Should call delegate method")
+    collectionView.setContentOffset(.horizontalOffset(x: screenHeight * 2.5), animated: false)
+    #expect(delegate.didPrefetchNextPageCalled)
   }
 
-  func testBatchNullState() {
+  // MARK: - Batch Null State
+
+  @Test("Should not fetch in null state")
+  func batchNullState() {
     let sut = Pagination()
-    // Test with default settings
     let context = PaginationContext()
     let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
@@ -60,10 +69,14 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 0.0,
       shouldRenderRTLLayout: false,
       flipsHorizontallyInOppositeLayoutDirection: false)
-    XCTAssertFalse(shouldFetch, "Should not fetch in the null state")
+    #expect(!shouldFetch)
+  }
 
-    // Test RTL
-    let shouldFetchRTL = sut.shouldPrefetchNextPage(
+  @Test("Should not fetch in null state with RTL layout")
+  func batchNullStateRTL() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
       scrollableDirections: .vertical,
@@ -74,10 +87,14 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 0.0,
       shouldRenderRTLLayout: true,
       flipsHorizontallyInOppositeLayoutDirection: false)
-    XCTAssertFalse(shouldFetchRTL, "Should not fetch in the null state with RTL layout")
+    #expect(!shouldFetch)
+  }
 
-    // Test RTL with a layout that automatically flips (should act the same as LTR)
-    let shouldFetchRTLFlip = sut.shouldPrefetchNextPage(
+  @Test("Should not fetch in null state with RTL flip layout")
+  func batchNullStateRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
       scrollableDirections: .vertical,
@@ -88,10 +105,13 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 0.0,
       shouldRenderRTLLayout: true,
       flipsHorizontallyInOppositeLayoutDirection: true)
-    XCTAssertFalse(shouldFetchRTLFlip, "Should not fetch in the null state with RTL flip layout")
+    #expect(!shouldFetch)
   }
 
-  func testBatchAlreadyFetching() {
+  // MARK: - Already Fetching
+
+  @Test("Should not fetch when context is already fetching")
+  func batchAlreadyFetching() {
     let sut = Pagination()
     let context = PaginationContext()
     context.start()
@@ -105,44 +125,52 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .passingPoint,
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertFalse(shouldFetch, "Should not fetch when context is already fetching")
-
-    // Test RTL
-    let shouldFetchRTL = sut.shouldPrefetchNextPage(
-      context: context,
-      scrollDirection: .down,
-      scrollableDirections: .vertical,
-      isScrollViewVisible: true,
-      scrollViewBounds: .passingRect,
-      scrollViewContentSize: .passingSize,
-      scrollViewContentOffset: .passingPoint,
-      leadingScreens: 1.0,
-      shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertFalse(
-      shouldFetchRTL, "Should not fetch when context is already fetching in RTL layout")
-
-    // Test RTL with a layout that automatically flips (should act the same as LTR)
-    let shouldFetchRTLFlip = sut.shouldPrefetchNextPage(
-      context: context,
-      scrollDirection: .down,
-      scrollableDirections: .vertical,
-      isScrollViewVisible: true,
-      scrollViewBounds: .passingRect,
-      scrollViewContentSize: .passingSize,
-      scrollViewContentOffset: .passingPoint,
-      leadingScreens: 1.0,
-      shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: true
-    )
-    XCTAssertFalse(
-      shouldFetchRTLFlip, "Should not fetch when context is already fetching in RTL flip layout")
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(!shouldFetch)
   }
 
-  func testIsNotVisible() {
+  @Test("Should not fetch when context is already fetching in RTL layout")
+  func batchAlreadyFetchingRTL() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    context.start()
+    let shouldFetch = sut.shouldPrefetchNextPage(
+      context: context,
+      scrollDirection: .down,
+      scrollableDirections: .vertical,
+      isScrollViewVisible: true,
+      scrollViewBounds: .passingRect,
+      scrollViewContentSize: .passingSize,
+      scrollViewContentOffset: .passingPoint,
+      leadingScreens: 1.0,
+      shouldRenderRTLLayout: true,
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(!shouldFetch)
+  }
+
+  @Test("Should not fetch when context is already fetching in RTL flip layout")
+  func batchAlreadyFetchingRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    context.start()
+    let shouldFetch = sut.shouldPrefetchNextPage(
+      context: context,
+      scrollDirection: .down,
+      scrollableDirections: .vertical,
+      isScrollViewVisible: true,
+      scrollViewBounds: .passingRect,
+      scrollViewContentSize: .passingSize,
+      scrollViewContentOffset: .passingPoint,
+      leadingScreens: 1.0,
+      shouldRenderRTLLayout: true,
+      flipsHorizontallyInOppositeLayoutDirection: true)
+    #expect(!shouldFetch)
+  }
+
+  // MARK: - Not Visible
+
+  @Test("Should not fetch when scroll view is not visible")
+  func isNotVisible() {
     let sut = Pagination()
     let context = PaginationContext()
     let shouldFetch = sut.shouldPrefetchNextPage(
@@ -155,75 +183,91 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .passingPoint,
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertFalse(shouldFetch, "Should not fetch when scroll view is not visible")
-
-    // Test RTL
-    let shouldFetchRTL = sut.shouldPrefetchNextPage(
-      context: context,
-      scrollDirection: .down,
-      scrollableDirections: .vertical,
-      isScrollViewVisible: false,
-      scrollViewBounds: .passingRect,
-      scrollViewContentSize: .passingSize,
-      scrollViewContentOffset: .passingPoint,
-      leadingScreens: 1.0,
-      shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertFalse(
-      shouldFetchRTL, "Should not fetch when scroll view is not visible in RTL layout")
-
-    // Test RTL with a layout that automatically flips (should act the same as LTR)
-    let shouldFetchRTLFlip = sut.shouldPrefetchNextPage(
-      context: context,
-      scrollDirection: .down,
-      scrollableDirections: .vertical,
-      isScrollViewVisible: false,
-      scrollViewBounds: .passingRect,
-      scrollViewContentSize: .passingSize,
-      scrollViewContentOffset: .passingPoint,
-      leadingScreens: 1.0,
-      shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: true
-    )
-    XCTAssertFalse(
-      shouldFetchRTLFlip, "Should not fetch when scroll view is not visible in RTL flip layout")
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(!shouldFetch)
   }
 
-  func testScrollDirection() {
+  @Test("Should not fetch when scroll view is not visible in RTL layout")
+  func isNotVisibleRTL() {
     let sut = Pagination()
-    let directionUp = sut.detectScrollDirection(
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
+      context: context,
+      scrollDirection: .down,
+      scrollableDirections: .vertical,
+      isScrollViewVisible: false,
+      scrollViewBounds: .passingRect,
+      scrollViewContentSize: .passingSize,
+      scrollViewContentOffset: .passingPoint,
+      leadingScreens: 1.0,
+      shouldRenderRTLLayout: true,
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(!shouldFetch)
+  }
+
+  @Test("Should not fetch when scroll view is not visible in RTL flip layout")
+  func isNotVisibleRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
+      context: context,
+      scrollDirection: .down,
+      scrollableDirections: .vertical,
+      isScrollViewVisible: false,
+      scrollViewBounds: .passingRect,
+      scrollViewContentSize: .passingSize,
+      scrollViewContentOffset: .passingPoint,
+      leadingScreens: 1.0,
+      shouldRenderRTLLayout: true,
+      flipsHorizontallyInOppositeLayoutDirection: true)
+    #expect(!shouldFetch)
+  }
+
+  // MARK: - Scroll Direction Detection
+
+  @Test("Detects upward scroll direction")
+  func scrollDirectionUp() {
+    let sut = Pagination()
+    let direction = sut.detectScrollDirection(
       oldOffset: .verticalOffset(y: 1),
-      newOffset: .zero
-    )
-    XCTAssertTrue(directionUp == .up, "Scroll direction should be up")
+      newOffset: .zero)
+    #expect(direction == .up)
+  }
 
-    let directionDown = sut.detectScrollDirection(
+  @Test("Detects downward scroll direction")
+  func scrollDirectionDown() {
+    let sut = Pagination()
+    let direction = sut.detectScrollDirection(
       oldOffset: .zero,
-      newOffset: .verticalOffset(y: 1)
-    )
-    XCTAssertTrue(directionDown == .down, "Scroll direction should be down")
+      newOffset: .verticalOffset(y: 1))
+    #expect(direction == .down)
+  }
 
-    let directionRight = sut.detectScrollDirection(
+  @Test("Detects rightward scroll direction")
+  func scrollDirectionRight() {
+    let sut = Pagination()
+    let direction = sut.detectScrollDirection(
       oldOffset: .zero,
-      newOffset: .horizontalOffset(x: 1)
-    )
-    XCTAssertTrue(directionRight == .right, "Scroll direction should be right")
+      newOffset: .horizontalOffset(x: 1))
+    #expect(direction == .right)
+  }
 
-    let directionLeft = sut.detectScrollDirection(
+  @Test("Detects leftward scroll direction")
+  func scrollDirectionLeft() {
+    let sut = Pagination()
+    let direction = sut.detectScrollDirection(
       oldOffset: .horizontalOffset(x: 1),
-      newOffset: .zero
-    )
-    XCTAssertTrue(directionLeft == .left, "Scroll direction should be left")
+      newOffset: .zero)
+    #expect(direction == .left)
   }
 
-  func testUnsupportedScrollDirections() {
+  // MARK: - Supported Scroll Directions
+
+  @Test("Should fetch for scrolling right in horizontal direction")
+  func fetchScrollingRight() {
     let sut = Pagination()
     let context = PaginationContext()
-    // Test scrolling right
-    let fetchRight = sut.shouldPrefetchNextPage(
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .right,
       scrollableDirections: .horizontal,
@@ -234,10 +278,14 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
       flipsHorizontallyInOppositeLayoutDirection: false)
-    XCTAssertTrue(fetchRight, "Should fetch for scrolling right")
+    #expect(shouldFetch)
+  }
 
-    // Test scrolling down
-    let fetchDown = sut.shouldPrefetchNextPage(
+  @Test("Should fetch for scrolling down in vertical direction")
+  func fetchScrollingDown() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
       scrollableDirections: .vertical,
@@ -248,10 +296,14 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
       flipsHorizontallyInOppositeLayoutDirection: false)
-    XCTAssertTrue(fetchDown, "Should fetch for scrolling down")
+    #expect(shouldFetch)
+  }
 
-    // Test scrolling up
-    let fetchUp = sut.shouldPrefetchNextPage(
+  @Test("Should not fetch for scrolling up in vertical direction")
+  func noFetchScrollingUp() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .up,
       scrollableDirections: .vertical,
@@ -262,10 +314,14 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
       flipsHorizontallyInOppositeLayoutDirection: false)
-    XCTAssertFalse(fetchUp, "Should not fetch for scrolling up")
+    #expect(!shouldFetch)
+  }
 
-    // Test scrolling left
-    let fetchLeft = sut.shouldPrefetchNextPage(
+  @Test("Should not fetch for scrolling left in horizontal direction")
+  func noFetchScrollingLeft() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .left,
       scrollableDirections: .horizontal,
@@ -276,10 +332,16 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
       flipsHorizontallyInOppositeLayoutDirection: false)
-    XCTAssertFalse(fetchLeft, "Should not fetch for scrolling left")
+    #expect(!shouldFetch)
+  }
 
-    // Test RTL layout for scrolling right
-    let fetchRightRTL = sut.shouldPrefetchNextPage(
+  // MARK: - RTL Scroll Directions
+
+  @Test("Should not fetch for scrolling right in RTL layout")
+  func noFetchScrollingRightRTL() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .right,
       scrollableDirections: .horizontal,
@@ -290,10 +352,14 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
       flipsHorizontallyInOppositeLayoutDirection: false)
-    XCTAssertFalse(fetchRightRTL, "Should not fetch for scrolling right in RTL layout")
+    #expect(!shouldFetch)
+  }
 
-    // Test RTL layout for scrolling down
-    let fetchDownRTL = sut.shouldPrefetchNextPage(
+  @Test("Should fetch for scrolling down in RTL layout")
+  func fetchScrollingDownRTL() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
       scrollableDirections: .vertical,
@@ -304,10 +370,14 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
       flipsHorizontallyInOppositeLayoutDirection: false)
-    XCTAssertTrue(fetchDownRTL, "Should fetch for scrolling down in RTL layout")
+    #expect(shouldFetch)
+  }
 
-    // Test RTL layout for scrolling up
-    let fetchUpRTL = sut.shouldPrefetchNextPage(
+  @Test("Should not fetch for scrolling up in RTL layout")
+  func noFetchScrollingUpRTL() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .up,
       scrollableDirections: .vertical,
@@ -318,10 +388,14 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
       flipsHorizontallyInOppositeLayoutDirection: false)
-    XCTAssertFalse(fetchUpRTL, "Should not fetch for scrolling up in RTL layout")
+    #expect(!shouldFetch)
+  }
 
-    // Test RTL layout for scrolling left
-    let fetchLeftRTL = sut.shouldPrefetchNextPage(
+  @Test("Should fetch for scrolling left in RTL layout")
+  func fetchScrollingLeftRTL() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .left,
       scrollableDirections: .horizontal,
@@ -332,10 +406,16 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
       flipsHorizontallyInOppositeLayoutDirection: false)
-    XCTAssertTrue(fetchLeftRTL, "Should fetch for scrolling left in RTL layout")
+    #expect(shouldFetch)
+  }
 
-    // Test RTL layout with automatic flipping for scrolling right
-    let fetchRightRTLFlip = sut.shouldPrefetchNextPage(
+  // MARK: - RTL Flip Scroll Directions
+
+  @Test("Should not fetch for scrolling right with RTL flip layout")
+  func noFetchScrollingRightRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .right,
       scrollableDirections: .horizontal,
@@ -346,10 +426,14 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
       flipsHorizontallyInOppositeLayoutDirection: true)
-    XCTAssertFalse(fetchRightRTLFlip, "Should not fetch for scrolling right with RTL flip layout")
+    #expect(!shouldFetch)
+  }
 
-    // Test RTL layout with automatic flipping for scrolling down
-    let fetchDownRTLFlip = sut.shouldPrefetchNextPage(
+  @Test("Should fetch for scrolling down with RTL flip layout")
+  func fetchScrollingDownRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
       scrollableDirections: .vertical,
@@ -360,10 +444,14 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
       flipsHorizontallyInOppositeLayoutDirection: true)
-    XCTAssertTrue(fetchDownRTLFlip, "Should fetch for scrolling down with RTL flip layout")
+    #expect(shouldFetch)
+  }
 
-    // Test RTL layout with automatic flipping for scrolling up
-    let fetchUpRTLFlip = sut.shouldPrefetchNextPage(
+  @Test("Should not fetch for scrolling up with RTL flip layout")
+  func noFetchScrollingUpRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .up,
       scrollableDirections: .vertical,
@@ -374,10 +462,14 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
       flipsHorizontallyInOppositeLayoutDirection: true)
-    XCTAssertFalse(fetchUpRTLFlip, "Should not fetch for scrolling up with RTL flip layout")
+    #expect(!shouldFetch)
+  }
 
-    // Test RTL layout with automatic flipping for scrolling left
-    let fetchLeftRTLFlip = sut.shouldPrefetchNextPage(
+  @Test("Should fetch for scrolling left with RTL flip layout")
+  func fetchScrollingLeftRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .left,
       scrollableDirections: .horizontal,
@@ -388,14 +480,16 @@ final class PaginationTests: XCTestCase {
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
       flipsHorizontallyInOppositeLayoutDirection: true)
-    XCTAssertTrue(fetchLeftRTLFlip, "Should fetch for scrolling left with RTL flip layout")
+    #expect(shouldFetch)
   }
 
-  func testVerticalScrollToExactLeading() {
+  // MARK: - Vertical Scroll to Exact Leading
+
+  @Test("Fetch begins when vertically scrolling to exactly 1 leading screen away")
+  func verticalScrollToExactLeading() {
     let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
-    // Scroll to 1-screen top offset, height is 1 screen, so bottom is 1 screen away from the end of content
     let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
@@ -406,13 +500,16 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .verticalOffset(y: screen * 1.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertTrue(
-      shouldFetch, "Fetch should begin when vertically scrolling to exactly 1 leading screen away")
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(shouldFetch)
+  }
 
-    // Test RTL
-    let shouldFetchRTL = sut.shouldPrefetchNextPage(
+  @Test("Fetch begins when vertically scrolling to exactly 1 leading screen away in RTL layout")
+  func verticalScrollToExactLeadingRTL() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
       scrollableDirections: .vertical,
@@ -422,14 +519,17 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .verticalOffset(y: screen * 1.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertTrue(
-      shouldFetchRTL,
-      "Fetch should begin when vertically scrolling to exactly 1 leading screen away in RTL layout")
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(shouldFetch)
+  }
 
-    // Test RTL with a layout that automatically flips (should act the same as LTR)
-    let shouldFetchRTLFlip = sut.shouldPrefetchNextPage(
+  @Test(
+    "Fetch begins when vertically scrolling to exactly 1 leading screen away in RTL flip layout")
+  func verticalScrollToExactLeadingRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
       scrollableDirections: .vertical,
@@ -439,19 +539,17 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .verticalOffset(y: screen * 1.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: true
-    )
-    XCTAssertTrue(
-      shouldFetchRTLFlip,
-      "Fetch should begin when vertically scrolling to exactly 1 leading screen away in RTL flip layout"
-    )
+      flipsHorizontallyInOppositeLayoutDirection: true)
+    #expect(shouldFetch)
   }
 
-  func testVerticalScrollToLessThanLeading() {
+  // MARK: - Vertical Scroll Less Than Leading
+
+  @Test("Should not fetch when vertically scrolling less than the leading distance away")
+  func verticalScrollToLessThanLeading() {
     let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
-    // 3 screens of content, scroll only 1/2 of one screen
     let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
@@ -462,14 +560,17 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .verticalOffset(y: screen * 0.5),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertFalse(
-      shouldFetch,
-      "Fetch should not begin when vertically scrolling less than the leading distance away")
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(!shouldFetch)
+  }
 
-    // Test RTL
-    let shouldFetchRTL = sut.shouldPrefetchNextPage(
+  @Test(
+    "Should not fetch when vertically scrolling less than the leading distance away in RTL layout")
+  func verticalScrollToLessThanLeadingRTL() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
       scrollableDirections: .vertical,
@@ -479,14 +580,18 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .verticalOffset(y: screen * 0.5),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertFalse(
-      shouldFetchRTL,
-      "Fetch should not begin when vertically scrolling less than the leading distance away")
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(!shouldFetch)
+  }
 
-    // Test RTL with a layout that automatically flips (should act the same as LTR)
-    let shouldFetchRTLFlip = sut.shouldPrefetchNextPage(
+  @Test(
+    "Should not fetch when vertically scrolling less than the leading distance away in RTL flip layout"
+  )
+  func verticalScrollToLessThanLeadingRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
       scrollableDirections: .vertical,
@@ -496,18 +601,17 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .verticalOffset(y: screen * 0.5),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: true
-    )
-    XCTAssertFalse(
-      shouldFetchRTLFlip,
-      "Fetch should not begin when vertically scrolling less than the leading distance away")
+      flipsHorizontallyInOppositeLayoutDirection: true)
+    #expect(!shouldFetch)
   }
 
-  func testVerticalScrollingPastContentSize() {
+  // MARK: - Vertical Scrolling Past Content Size
+
+  @Test("Fetch begins when vertically scrolling past the content size")
+  func verticalScrollingPastContentSize() {
     let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
-    // 3 screens of content, top offset to 3-screens, height 1 screen, so it's 1 screen past the leading
     let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
@@ -518,12 +622,16 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .verticalOffset(y: screen * 3.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertTrue(shouldFetch, "Fetch should begin when vertically scrolling past the content size")
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(shouldFetch)
+  }
 
-    // Test RTL
-    let shouldFetchRTL = sut.shouldPrefetchNextPage(
+  @Test("Fetch begins when vertically scrolling past the content size in RTL layout")
+  func verticalScrollingPastContentSizeRTL() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
       scrollableDirections: .vertical,
@@ -533,14 +641,16 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .verticalOffset(y: screen * 3.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertTrue(
-      shouldFetchRTL,
-      "Fetch should begin when vertically scrolling past the content size in RTL layout")
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(shouldFetch)
+  }
 
-    // Test RTL with a layout that automatically flips (should act the same as LTR)
-    let shouldFetchRTLFlip = sut.shouldPrefetchNextPage(
+  @Test("Fetch begins when vertically scrolling past the content size in RTL flip layout")
+  func verticalScrollingPastContentSizeRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
       scrollableDirections: .vertical,
@@ -550,18 +660,17 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .verticalOffset(y: screen * 3.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: true
-    )
-    XCTAssertTrue(
-      shouldFetchRTLFlip,
-      "Fetch should begin when vertically scrolling past the content size in RTL flip layout")
+      flipsHorizontallyInOppositeLayoutDirection: true)
+    #expect(shouldFetch)
   }
 
-  func testHorizontalScrollToExactLeading() {
+  // MARK: - Horizontal Scroll to Exact Leading
+
+  @Test("Fetch begins when horizontally scrolling to exactly 1 leading screen away")
+  func horizontalScrollToExactLeading() {
     let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
-    // Scroll to 1-screen left offset, width is 1 screen, so right is 1 screen away from end of content
     let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .right,
@@ -572,14 +681,16 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .horizontalOffset(x: screen * 1.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertTrue(
-      shouldFetch, "Fetch should begin when horizontally scrolling to exactly 1 leading screen away"
-    )
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(shouldFetch)
+  }
 
-    // Test RTL
-    let shouldFetchRTL = sut.shouldPrefetchNextPage(
+  @Test("Fetch begins when horizontally scrolling to exactly 1 leading screen away in RTL layout")
+  func horizontalScrollToExactLeadingRTL() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .right,
       scrollableDirections: .vertical,
@@ -589,14 +700,17 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .horizontalOffset(x: screen * 1.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertTrue(
-      shouldFetchRTL,
-      "Fetch should begin when horizontally scrolling to exactly 1 leading screen away in RTL layout"
-    )
-    // Test RTL with a layout that automatically flips (should act the same as LTR)
-    let shouldFetchRTLFlip = sut.shouldPrefetchNextPage(
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(shouldFetch)
+  }
+
+  @Test(
+    "Fetch begins when horizontally scrolling to exactly 1 leading screen away in RTL flip layout")
+  func horizontalScrollToExactLeadingRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .right,
       scrollableDirections: .vertical,
@@ -606,19 +720,17 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .horizontalOffset(x: screen * 1.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: true
-    )
-    XCTAssertTrue(
-      shouldFetchRTLFlip,
-      "Fetch should begin when horizontally scrolling to exactly 1 leading screen away in RTL flip layout"
-    )
+      flipsHorizontallyInOppositeLayoutDirection: true)
+    #expect(shouldFetch)
   }
 
-  func testHorizontalScrollToLessThanLeading() {
+  // MARK: - Horizontal Scroll Less Than Leading
+
+  @Test("Should not fetch when horizontally scrolling less than the leading distance away")
+  func horizontalScrollToLessThanLeading() {
     let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
-    // 3 screens of content, scroll only 1/2 of one screen
     let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .left,
@@ -629,14 +741,17 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .horizontalOffset(x: screen * 0.5),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertFalse(
-      shouldFetch,
-      "Fetch should not begin when horizontally scrolling less than the leading distance away")
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(!shouldFetch)
+  }
 
-    // In RTL since scrolling is reversed, our remaining distance is actually our offset (0.5) which is less than our leading screen (1). So we do want to fetch
-    let shouldFetchRTL = sut.shouldPrefetchNextPage(
+  @Test(
+    "Should fetch when horizontally scrolling less than the leading distance away in RTL layout")
+  func horizontalScrollToLessThanLeadingRTL() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .left,
       scrollableDirections: .horizontal,
@@ -646,15 +761,18 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .horizontalOffset(x: screen * 0.5),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertTrue(
-      shouldFetchRTL,
-      "Fetch should begin when horizontally scrolling less than the leading distance away in RTL layout"
-    )
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(shouldFetch)
+  }
 
-    // Test RTL with a layout that automatically flips (should act the same as LTR)
-    let shouldFetchRTLFlip = sut.shouldPrefetchNextPage(
+  @Test(
+    "Should not fetch when horizontally scrolling less than the leading distance away in RTL flip layout"
+  )
+  func horizontalScrollToLessThanLeadingRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .left,
       scrollableDirections: .horizontal,
@@ -664,18 +782,17 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .horizontalOffset(x: screen * 0.5),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: true
-    )
-    XCTAssertFalse(
-      shouldFetchRTLFlip,
-      "Fetch should not begin when horizontally scrolling less than the leading distance away")
+      flipsHorizontallyInOppositeLayoutDirection: true)
+    #expect(!shouldFetch)
   }
 
-  func testHorizontalScrollingPastContentSize() {
+  // MARK: - Horizontal Scrolling Past Content Size
+
+  @Test("Fetch begins when horizontally scrolling past the content size")
+  func horizontalScrollingPastContentSize() {
     let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
-    // 3 screens of content, offset 3 screens, width 1 screen, so it's 1 screen past the leading
     let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
@@ -686,52 +803,56 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .horizontalOffset(x: screen * 3.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertTrue(
-      shouldFetch, "Fetch should begin when horizontally scrolling past the content size")
-
-    // In RTL scrolling is reversed, remaining distance is actually our offset (3) which is more than our leading screen (1). So we do not fetch
-    let shouldFetchRTL = sut.shouldPrefetchNextPage(
-      context: context,
-      scrollDirection: .down,
-      scrollableDirections: .horizontal,
-      isScrollViewVisible: true,
-      scrollViewBounds: .horizontalRect(width: screen),
-      scrollViewContentSize: .horizontalSize(width: screen * 3.0),
-      scrollViewContentOffset: .horizontalOffset(x: screen * 3.0),
-      leadingScreens: 1.0,
-      shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertFalse(
-      shouldFetchRTL,
-      "Fetch should not begin when horizontally scrolling past the content size in RTL layout")
-
-    // Test RTL with a layout that automatically flips (should act the same as LTR)
-    let shouldFetchFlipRTL = sut.shouldPrefetchNextPage(
-      context: context,
-      scrollDirection: .down,
-      scrollableDirections: .horizontal,
-      isScrollViewVisible: true,
-      scrollViewBounds: .horizontalRect(width: screen),
-      scrollViewContentSize: .horizontalSize(width: screen * 3.0),
-      scrollViewContentOffset: .horizontalOffset(x: screen * 3.0),
-      leadingScreens: 1.0,
-      shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: true
-    )
-    XCTAssertTrue(
-      shouldFetchFlipRTL,
-      "Fetch should begin when horizontally scrolling past the content size with flipped RTL layout"
-    )
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(shouldFetch)
   }
 
-  func testVerticalScrollingSmallContentSize() {
+  @Test("Should not fetch when horizontally scrolling past the content size in RTL layout")
+  func horizontalScrollingPastContentSizeRTL() {
     let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
-    // When the content size is smaller than the screen size, the target offset will always be 0
+    let shouldFetch = sut.shouldPrefetchNextPage(
+      context: context,
+      scrollDirection: .down,
+      scrollableDirections: .horizontal,
+      isScrollViewVisible: true,
+      scrollViewBounds: .horizontalRect(width: screen),
+      scrollViewContentSize: .horizontalSize(width: screen * 3.0),
+      scrollViewContentOffset: .horizontalOffset(x: screen * 3.0),
+      leadingScreens: 1.0,
+      shouldRenderRTLLayout: true,
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(!shouldFetch)
+  }
+
+  @Test(
+    "Fetch begins when horizontally scrolling past the content size with flipped RTL layout")
+  func horizontalScrollingPastContentSizeRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
+      context: context,
+      scrollDirection: .down,
+      scrollableDirections: .horizontal,
+      isScrollViewVisible: true,
+      scrollViewBounds: .horizontalRect(width: screen),
+      scrollViewContentSize: .horizontalSize(width: screen * 3.0),
+      scrollViewContentOffset: .horizontalOffset(x: screen * 3.0),
+      leadingScreens: 1.0,
+      shouldRenderRTLLayout: true,
+      flipsHorizontallyInOppositeLayoutDirection: true)
+    #expect(shouldFetch)
+  }
+
+  // MARK: - Vertical Small Content Size
+
+  @Test("Fetch begins when vertical content size is smaller than the screen")
+  func verticalScrollingSmallContentSize() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
     let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .down,
@@ -742,53 +863,55 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .verticalOffset(y: 0.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertTrue(
-      shouldFetch,
-      "Fetch should begin when the content size is smaller than the screen and the target offset is 0"
-    )
-
-    // Test RTL layout
-    let shouldFetchRTL = sut.shouldPrefetchNextPage(
-      context: context,
-      scrollDirection: .down,
-      scrollableDirections: .vertical,
-      isScrollViewVisible: true,
-      scrollViewBounds: .verticalRect(height: screen * 3),
-      scrollViewContentSize: .verticalSize(height: screen * 0.5),
-      scrollViewContentOffset: .verticalOffset(y: 0.0),
-      leadingScreens: 1.0,
-      shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertTrue(
-      shouldFetchRTL,
-      "Fetch should begin when the content size is smaller than the screen in RTL layout")
-
-    // Test RTL with a layout that automatically flips (should act the same as LTR)
-    let shouldFetchRTLFlip = sut.shouldPrefetchNextPage(
-      context: context,
-      scrollDirection: .down,
-      scrollableDirections: .vertical,
-      isScrollViewVisible: true,
-      scrollViewBounds: .verticalRect(height: screen * 3),
-      scrollViewContentSize: .verticalSize(height: screen * 0.5),
-      scrollViewContentOffset: .verticalOffset(y: 0.0),
-      leadingScreens: 1.0,
-      shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: true
-    )
-    XCTAssertTrue(
-      shouldFetchRTLFlip,
-      "Fetch should begin when the content size is smaller than the screen with flipped RTL layout")
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(shouldFetch)
   }
 
-  func testHorizontalScrollingSmallContentSize() {
+  @Test("Fetch begins when vertical content size is smaller than the screen in RTL layout")
+  func verticalScrollingSmallContentSizeRTL() {
     let sut = Pagination()
     let context = PaginationContext()
     let screen: CGFloat = 1.0
-    // When the content size is smaller than the screen size, the target offset will always be 0
+    let shouldFetch = sut.shouldPrefetchNextPage(
+      context: context,
+      scrollDirection: .down,
+      scrollableDirections: .vertical,
+      isScrollViewVisible: true,
+      scrollViewBounds: .verticalRect(height: screen * 3),
+      scrollViewContentSize: .verticalSize(height: screen * 0.5),
+      scrollViewContentOffset: .verticalOffset(y: 0.0),
+      leadingScreens: 1.0,
+      shouldRenderRTLLayout: true,
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(shouldFetch)
+  }
+
+  @Test("Fetch begins when vertical content size is smaller than the screen in RTL flip layout")
+  func verticalScrollingSmallContentSizeRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
+      context: context,
+      scrollDirection: .down,
+      scrollableDirections: .vertical,
+      isScrollViewVisible: true,
+      scrollViewBounds: .verticalRect(height: screen * 3),
+      scrollViewContentSize: .verticalSize(height: screen * 0.5),
+      scrollViewContentOffset: .verticalOffset(y: 0.0),
+      leadingScreens: 1.0,
+      shouldRenderRTLLayout: true,
+      flipsHorizontallyInOppositeLayoutDirection: true)
+    #expect(shouldFetch)
+  }
+
+  // MARK: - Horizontal Small Content Size
+
+  @Test("Fetch begins when horizontal content size is smaller than the screen")
+  func horizontalScrollingSmallContentSize() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
     let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .right,
@@ -799,15 +922,16 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .horizontalOffset(x: 0.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: false,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertTrue(
-      shouldFetch,
-      "Fetch should begin when the content size is smaller than the screen and the target offset is 0"
-    )
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(shouldFetch)
+  }
 
-    // Test RTL layout
-    let shouldFetchRTL = sut.shouldPrefetchNextPage(
+  @Test("Fetch begins when horizontal content size is smaller than the screen in RTL layout")
+  func horizontalScrollingSmallContentSizeRTL() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .right,
       scrollableDirections: .horizontal,
@@ -817,14 +941,16 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .horizontalOffset(x: 0.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: false
-    )
-    XCTAssertTrue(
-      shouldFetchRTL,
-      "Fetch should begin when the content size is smaller than the screen in RTL layout")
+      flipsHorizontallyInOppositeLayoutDirection: false)
+    #expect(shouldFetch)
+  }
 
-    // Test RTL with a layout that automatically flips (should act the same as LTR)
-    let shouldFetchRTLFlip = sut.shouldPrefetchNextPage(
+  @Test("Fetch begins when horizontal content size is smaller than the screen in RTL flip layout")
+  func horizontalScrollingSmallContentSizeRTLFlip() {
+    let sut = Pagination()
+    let context = PaginationContext()
+    let screen: CGFloat = 1.0
+    let shouldFetch = sut.shouldPrefetchNextPage(
       context: context,
       scrollDirection: .right,
       scrollableDirections: .horizontal,
@@ -834,11 +960,8 @@ final class PaginationTests: XCTestCase {
       scrollViewContentOffset: .horizontalOffset(x: 0.0),
       leadingScreens: 1.0,
       shouldRenderRTLLayout: true,
-      flipsHorizontallyInOppositeLayoutDirection: true
-    )
-    XCTAssertTrue(
-      shouldFetchRTLFlip,
-      "Fetch should begin when the content size is smaller than the screen with flipped RTL layout")
+      flipsHorizontallyInOppositeLayoutDirection: true)
+    #expect(shouldFetch)
   }
 }
 

--- a/Tests/PaginationTests/PaginationTests.swift
+++ b/Tests/PaginationTests/PaginationTests.swift
@@ -11,8 +11,8 @@ struct PaginationTests {
 
   @Test("Scroll view triggers delegate when scrolled past threshold")
   func scrollViewIntegration() {
-    let scrollView = MockScrollView()
-    let delegate = MockPaginationDelegate()
+    let scrollView = FakeScrollView()
+    let delegate = SpyPaginationDelegate()
     let screenHeight: CGFloat = 100
     scrollView.bounds = .verticalRect(height: screenHeight)
     scrollView.contentSize = .verticalSize(height: 3 * screenHeight)
@@ -25,8 +25,8 @@ struct PaginationTests {
 
   @Test("Table view triggers delegate when scrolled past threshold")
   func tableViewIntegration() {
-    let tableView = MockTableView()
-    let delegate = MockPaginationDelegate()
+    let tableView = FakeTableView()
+    let delegate = SpyPaginationDelegate()
     let screenHeight: CGFloat = 100
     tableView.bounds = .verticalRect(height: screenHeight)
     tableView.contentSize = .verticalSize(height: 3 * screenHeight)
@@ -40,10 +40,10 @@ struct PaginationTests {
   @Test("Collection view triggers delegate when scrolled past threshold")
   func collectionViewIntegration() {
     let screenHeight: CGFloat = 100
-    let collectionView = MockCollectionView(
+    let collectionView = FakeCollectionView(
       frame: .horizontalRect(width: screenHeight),
-      collectionViewLayout: MockCollectionViewLayout())
-    let delegate = MockPaginationDelegate()
+      collectionViewLayout: StubCollectionViewLayout())
+    let delegate = SpyPaginationDelegate()
     collectionView.contentSize = .horizontalSize(width: screenHeight * 3)
     collectionView.pagination.delegate = delegate
     collectionView.pagination.direction = .horizontal

--- a/Tests/PaginationTests/TestDoubles/FakeCollectionView.swift
+++ b/Tests/PaginationTests/TestDoubles/FakeCollectionView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class MockTableView: UIScrollView {
+final class FakeCollectionView: UICollectionView {
   var isVisible: Bool = true
   var _contentOffset: CGPoint = .zero
 
@@ -21,5 +21,13 @@ final class MockTableView: UIScrollView {
 
   override func setContentOffset(_ contentOffset: CGPoint, animated: Bool) {
     self.contentOffset = contentOffset
+  }
+}
+
+final class StubCollectionViewLayout: UICollectionViewLayout {
+  var _flipsHorizontallyInOppositeLayoutDirection: Bool = true
+
+  override var flipsHorizontallyInOppositeLayoutDirection: Bool {
+    return _flipsHorizontallyInOppositeLayoutDirection
   }
 }

--- a/Tests/PaginationTests/TestDoubles/FakeScrollView.swift
+++ b/Tests/PaginationTests/TestDoubles/FakeScrollView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class MockCollectionView: UICollectionView {
+final class FakeScrollView: UIScrollView {
   var isVisible: Bool = true
   var _contentOffset: CGPoint = .zero
 
@@ -21,13 +21,5 @@ final class MockCollectionView: UICollectionView {
 
   override func setContentOffset(_ contentOffset: CGPoint, animated: Bool) {
     self.contentOffset = contentOffset
-  }
-}
-
-final class MockCollectionViewLayout: UICollectionViewLayout {
-  var _flipsHorizontallyInOppositeLayoutDirection: Bool = true
-
-  override var flipsHorizontallyInOppositeLayoutDirection: Bool {
-    return _flipsHorizontallyInOppositeLayoutDirection
   }
 }

--- a/Tests/PaginationTests/TestDoubles/FakeTableView.swift
+++ b/Tests/PaginationTests/TestDoubles/FakeTableView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class FakeTableView: UIScrollView {
+final class FakeTableView: UITableView {
   var isVisible: Bool = true
   var _contentOffset: CGPoint = .zero
 

--- a/Tests/PaginationTests/TestDoubles/FakeTableView.swift
+++ b/Tests/PaginationTests/TestDoubles/FakeTableView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class MockScrollView: UIScrollView {
+final class FakeTableView: UIScrollView {
   var isVisible: Bool = true
   var _contentOffset: CGPoint = .zero
 

--- a/Tests/PaginationTests/TestDoubles/SpyPaginationDelegate.swift
+++ b/Tests/PaginationTests/TestDoubles/SpyPaginationDelegate.swift
@@ -2,7 +2,7 @@ import Dispatch
 
 @testable import Pagination
 
-final class MockPaginationDelegate: PaginationDelegate {
+final class SpyPaginationDelegate: PaginationDelegate {
   nonisolated(unsafe) var didPrefetchNextPageCalled = false
 
   func pagination(_ pagination: Pagination, prefetchNextPageWith context: PaginationContext) {

--- a/Tests/PaginationTests/TestDoubles/SpyPaginationDelegate.swift
+++ b/Tests/PaginationTests/TestDoubles/SpyPaginationDelegate.swift
@@ -6,7 +6,6 @@ final class SpyPaginationDelegate: PaginationDelegate {
   nonisolated(unsafe) var didPrefetchNextPageCalled = false
 
   func pagination(_ pagination: Pagination, prefetchNextPageWith context: PaginationContext) {
-    context.start()
     self.didPrefetchNextPageCalled = true
     context.finish(true)
   }

--- a/Tests/PaginationTests/UIScrollViewPaginationTests.swift
+++ b/Tests/PaginationTests/UIScrollViewPaginationTests.swift
@@ -7,51 +7,51 @@ import UIKit
 @MainActor
 struct UIScrollViewPaginationTests {
 
-  let mockScrollView = UIScrollView()
-  let mockDelegate = MockPaginationDelegate()
+  let scrollView = UIScrollView()
+  let delegate = SpyPaginationDelegate()
 
   @Test("Get pagination returns associated instance with scroll view set")
   func getPagination() {
-    let pagination = mockScrollView.pagination
+    let pagination = scrollView.pagination
     #expect(pagination.scrollView != nil)
   }
 
   @Test("Set pagination associates the given instance")
   func setPagination() {
     let pagination = Pagination()
-    mockScrollView.pagination = pagination
-    #expect(mockScrollView.pagination === pagination)
+    scrollView.pagination = pagination
+    #expect(scrollView.pagination === pagination)
   }
 
   @Test("Toggle pagination enabled state")
   func togglePaginationEnabled() {
-    mockScrollView.pagination.isEnabled = false
-    #expect(!mockScrollView.pagination.isEnabled)
-    mockScrollView.pagination.isEnabled = true
-    #expect(mockScrollView.pagination.isEnabled)
+    scrollView.pagination.isEnabled = false
+    #expect(!scrollView.pagination.isEnabled)
+    scrollView.pagination.isEnabled = true
+    #expect(scrollView.pagination.isEnabled)
   }
 
   @Test("Set and unset pagination delegate")
   func setPaginationDelegate() {
-    mockScrollView.pagination.delegate = mockDelegate
-    #expect(mockScrollView.pagination.delegate != nil)
-    mockScrollView.pagination.delegate = nil
-    #expect(mockScrollView.pagination.delegate == nil)
+    scrollView.pagination.delegate = delegate
+    #expect(scrollView.pagination.delegate != nil)
+    scrollView.pagination.delegate = nil
+    #expect(scrollView.pagination.delegate == nil)
   }
 
   @Test("Set pagination direction")
   func setPaginationDirection() {
-    mockScrollView.pagination.direction = .horizontal
-    #expect(mockScrollView.pagination.direction == .horizontal)
-    mockScrollView.pagination.direction = .vertical
-    #expect(mockScrollView.pagination.direction == .vertical)
+    scrollView.pagination.direction = .horizontal
+    #expect(scrollView.pagination.direction == .horizontal)
+    scrollView.pagination.direction = .vertical
+    #expect(scrollView.pagination.direction == .vertical)
   }
 
   @Test("Set pagination leading screens for prefetching")
   func setPaginationLeadingScreens() {
-    mockScrollView.pagination.leadingScreensForPrefetching = 3
-    #expect(mockScrollView.pagination.leadingScreensForPrefetching == 3)
-    mockScrollView.pagination.leadingScreensForPrefetching = 1
-    #expect(mockScrollView.pagination.leadingScreensForPrefetching == 1)
+    scrollView.pagination.leadingScreensForPrefetching = 3
+    #expect(scrollView.pagination.leadingScreensForPrefetching == 3)
+    scrollView.pagination.leadingScreensForPrefetching = 1
+    #expect(scrollView.pagination.leadingScreensForPrefetching == 1)
   }
 }

--- a/Tests/PaginationTests/UIScrollViewPaginationTests.swift
+++ b/Tests/PaginationTests/UIScrollViewPaginationTests.swift
@@ -1,59 +1,57 @@
-import XCTest
+import Testing
+import UIKit
 
 @testable import Pagination
 
+@Suite("UIScrollView Pagination")
 @MainActor
-final class UIScrollViewPaginationTests: XCTestCase {
+struct UIScrollViewPaginationTests {
 
-  var mockScrollView: UIScrollView!
-  var mockDelegate: MockPaginationDelegate!
+  let mockScrollView = UIScrollView()
+  let mockDelegate = MockPaginationDelegate()
 
-  override func setUp() async throws {
-    mockScrollView = UIScrollView()
-    mockDelegate = MockPaginationDelegate()
-  }
-
-  override func tearDown() async throws {
-    mockScrollView = nil
-    mockDelegate = nil
-  }
-
-  func testGetPagination() {
+  @Test("Get pagination returns associated instance with scroll view set")
+  func getPagination() {
     let pagination = mockScrollView.pagination
-    XCTAssertNotNil(pagination.scrollView)
+    #expect(pagination.scrollView != nil)
   }
 
-  func testSetPagination() {
+  @Test("Set pagination associates the given instance")
+  func setPagination() {
     let pagination = Pagination()
     mockScrollView.pagination = pagination
-    XCTAssertTrue(mockScrollView.pagination === pagination)
+    #expect(mockScrollView.pagination === pagination)
   }
 
-  func testTogglePaginationEnabled() {
+  @Test("Toggle pagination enabled state")
+  func togglePaginationEnabled() {
     mockScrollView.pagination.isEnabled = false
-    XCTAssertFalse(mockScrollView.pagination.isEnabled)
+    #expect(!mockScrollView.pagination.isEnabled)
     mockScrollView.pagination.isEnabled = true
-    XCTAssertTrue(mockScrollView.pagination.isEnabled == true)
+    #expect(mockScrollView.pagination.isEnabled)
   }
 
-  func testSetPaginationDelegate() {
+  @Test("Set and unset pagination delegate")
+  func setPaginationDelegate() {
     mockScrollView.pagination.delegate = mockDelegate
-    XCTAssertNotNil(mockScrollView.pagination.delegate)
+    #expect(mockScrollView.pagination.delegate != nil)
     mockScrollView.pagination.delegate = nil
-    XCTAssertNil(mockScrollView.pagination.delegate)
+    #expect(mockScrollView.pagination.delegate == nil)
   }
 
-  func testSetPaginationDirection() {
+  @Test("Set pagination direction")
+  func setPaginationDirection() {
     mockScrollView.pagination.direction = .horizontal
-    XCTAssertTrue(mockScrollView.pagination.direction == .horizontal)
+    #expect(mockScrollView.pagination.direction == .horizontal)
     mockScrollView.pagination.direction = .vertical
-    XCTAssertTrue(mockScrollView.pagination.direction == .vertical)
+    #expect(mockScrollView.pagination.direction == .vertical)
   }
 
-  func testSetPaginationLeadingScreens() {
+  @Test("Set pagination leading screens for prefetching")
+  func setPaginationLeadingScreens() {
     mockScrollView.pagination.leadingScreensForPrefetching = 3
-    XCTAssertTrue(mockScrollView.pagination.leadingScreensForPrefetching == 3)
+    #expect(mockScrollView.pagination.leadingScreensForPrefetching == 3)
     mockScrollView.pagination.leadingScreensForPrefetching = 1
-    XCTAssertTrue(mockScrollView.pagination.leadingScreensForPrefetching == 1)
+    #expect(mockScrollView.pagination.leadingScreensForPrefetching == 1)
   }
 }

--- a/Tests/PaginationTests/UIScrollViewPaginationTests.swift
+++ b/Tests/PaginationTests/UIScrollViewPaginationTests.swift
@@ -2,21 +2,18 @@ import XCTest
 
 @testable import Pagination
 
+@MainActor
 final class UIScrollViewPaginationTests: XCTestCase {
 
   var mockScrollView: UIScrollView!
   var mockDelegate: MockPaginationDelegate!
 
-  override func setUp() {
-    super.setUp()
-
+  override func setUp() async throws {
     mockScrollView = UIScrollView()
     mockDelegate = MockPaginationDelegate()
   }
 
-  override func tearDown() {
-    super.tearDown()
-
+  override func tearDown() async throws {
     mockScrollView = nil
     mockDelegate = nil
   }


### PR DESCRIPTION
### Summary
Migrate from Swift 5.9 to Swift 6 language mode (swift-tools-version 6.2)
Bump minimum deployment target from iOS 12 to iOS 13
Adopt Swift Testing framework for all unit tests
Rename test doubles to use proper terminology (Spy, Fake, Stub)

###  Breaking Changes
Minimum deployment target is now iOS 13 (was iOS 12)
Pagination class is now public final (was open) — subclassing from outside the module is no longer supported