### PR TITLE
refactor: move context.start() call to delegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Implement the delegate method to fetch data for the new page
 
 ```swift
 func pagination(_ pagination: Pagination, prefetchNextPageWith context: PaginationContext) {
+    context.start()
     // Fetch the next page of data from your source
     fetchData(forPage: nextPage) { result in
         switch result {
@@ -58,7 +59,7 @@ func pagination(_ pagination: Pagination, prefetchNextPageWith context: Paginati
 ```
 
 > [!IMPORTANT]
-> It is essential to call `context.finish(_:)` once the data loading is complete to accurately update the pagination state.
+> It is essential to call `context.start()` when beginning a fetch and `context.finish(_:)` once the data loading is complete to accurately update the pagination state.
 
 To disable pagination, set the `isEnabled` property to `false`. This will stop pagination from monitoring the scrollable view
 

--- a/Sources/Pagination.swift
+++ b/Sources/Pagination.swift
@@ -45,6 +45,7 @@
 /// extension FeedViewController: PaginationDelegate {
 ///
 ///     func pagination(_ pagination: Pagination, prefetchNextPageWith context: PaginationContext) {
+///         context.start()
 ///         let nextPage = currentPage + 1
 ///         feedProvider.provideFeed(page: nextPage, pageSize: 20) { [weak self] result in
 ///             switch result {
@@ -60,7 +61,7 @@
 ///     }
 /// }
 /// ```
-/// > Warning: It is mandatory to call `context.finish(_:)` with either `true` or `false` once the data loading is complete, to accurately reflect the pagination state.
+/// > Warning: It is mandatory to call `context.start()` when beginning a fetch and `context.finish(_:)` with either `true` or `false` once the data loading is complete, to accurately reflect the pagination state.
 ///
 /// This class provides methods to monitor scroll view events and manage pagination state efficiently.
 @MainActor
@@ -241,7 +242,6 @@
       shouldRenderRTLLayout: shouldRenderRTLLayout,
       flipsHorizontallyInOppositeLayoutDirection: flipsHorizontallyInOppositeLayoutDirection)
     {
-      context.start()
       delegate.pagination(self, prefetchNextPageWith: context)
     }
   }

--- a/Sources/UIScrollView+Pagination.swift
+++ b/Sources/UIScrollView+Pagination.swift
@@ -18,7 +18,7 @@ extension PlatformScrollView {
   /// - Note: The `Pagination` instance monitors the scroll view's content offset to determine when to request additional data.
   /// This is particularly useful when implementing infinite scrolling or batch data loading in large lists.
   ///
-  /// > Warning: It is mandatory to call `context.finish(_:)` with either `true` or `false` once the data loading is complete, to accurately reflect the pagination state.
+  /// > Warning: It is mandatory to call `context.start()` when beginning a fetch and `context.finish(_:)` with either `true` or `false` once the data loading is complete, to accurately reflect the pagination state.
   @objc public var pagination: Pagination {
     get {
       if let pagination = objc_getAssociatedObject(self, &paginationKey) as? Pagination {

--- a/Tests/TestDoubles/SpyPaginationDelegate.swift
+++ b/Tests/TestDoubles/SpyPaginationDelegate.swift
@@ -6,6 +6,7 @@ final class SpyPaginationDelegate: PaginationDelegate {
   nonisolated(unsafe) var didPrefetchNextPageCalled = false
 
   func pagination(_ pagination: Pagination, prefetchNextPageWith context: PaginationContext) {
+    context.start()
     self.didPrefetchNextPageCalled = true
     context.finish(true)
   }


### PR DESCRIPTION
## Summary
- Remove `context.start()` from `Pagination.prefetchIfNeeded` — the delegate is now responsible for starting the context when it begins fetching.
- Update the inline doc example, `UIScrollView+Pagination` warning, and README to show delegates calling `context.start()` before fetching.
- Update `SpyPaginationDelegate` to mirror the new contract.