### PR TITLE
feat: support Swift 6.0 and 6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.2
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
## Summary
- Lower `swift-tools-version` from 6.2 to 6.0 so the package can be built with Swift 6.0, 6.1, and 6.2 toolchains. No API or source changes.