### PR TITLE
feat: add SwiftUI support

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -22,6 +22,8 @@ jobs:
           - build-examples-ios
           - build-examples-macos
           - build-objc-ios
+          - build-swiftui-ios
+          - build-swiftui-macos
 
     steps:
       - uses: actions/checkout@v4

--- a/Examples/Shared/RepositoriesViewModel.swift
+++ b/Examples/Shared/RepositoriesViewModel.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 @MainActor
-final class RepositoriesViewModel {
+final class RepositoriesViewModel: ObservableObject {
   @Published private(set) var repositories: [RepositoryViewModel] = []
   @Published private(set) var hasMorePages = true
   private(set) var currentPage = 0
@@ -23,7 +23,7 @@ final class RepositoriesViewModel {
   }
 }
 
-struct RepositoryViewModel: Hashable, Sendable {
+struct RepositoryViewModel: Hashable, Sendable, Identifiable {
   let id: Int
   let title: String
   let subtitle: String

--- a/Examples/SwiftUI/RepositoriesView.swift
+++ b/Examples/SwiftUI/RepositoriesView.swift
@@ -1,0 +1,51 @@
+import Pagination
+import SwiftUI
+
+/// A SwiftUI view that lists popular GitHub repositories using the `.pagination` modifier.
+///
+/// Demonstrates the SwiftUI-native surface of the Pagination library:
+/// - `.paginationEnabled(_:)` is bound to `hasMorePages` so the library stops prefetching
+///   once the final page has been loaded.
+/// - `.pagination(state:action:)` wraps the async fetch and transitions the `state` binding
+///   through `.started` → `.completed` / `.failed` automatically.
+struct RepositoriesView: View {
+  @StateObject private var viewModel = RepositoriesViewModel()
+  @State private var state: PaginationState?
+
+  var body: some View {
+    List(viewModel.repositories) { item in
+      VStack(alignment: .leading, spacing: 4) {
+        Text(item.title)
+          .font(.headline)
+        Text(item.subtitle)
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+      }
+      .padding(.vertical, 4)
+    }
+    .overlay {
+      if viewModel.repositories.isEmpty, state == .started {
+        ProgressView()
+      }
+    }
+    .safeAreaInset(edge: .bottom) {
+      if state == .started, !viewModel.repositories.isEmpty {
+        ProgressView()
+          .padding()
+      }
+    }
+    .paginationDirection(.vertical)
+    .paginationLeadingScreens(2.0)
+    .paginationEnabled(viewModel.hasMorePages)
+    .pagination(state: $state) {
+      try await viewModel.fetchNextPage()
+    }
+  }
+}
+
+#Preview("Popular Repositories") {
+  NavigationStack {
+    RepositoriesView()
+      .navigationTitle("Popular Repositories")
+  }
+}

--- a/Examples/SwiftUI/SwiftUIExampleApp.swift
+++ b/Examples/SwiftUI/SwiftUIExampleApp.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+@main
+struct SwiftUIExampleApp: App {
+  var body: some Scene {
+    WindowGroup {
+      NavigationStack {
+        RepositoriesView()
+          .navigationTitle("Popular Repositories")
+          #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+          #endif
+      }
+    }
+    #if os(macOS)
+      .windowStyle(.titleBar)
+    #endif
+  }
+}

--- a/Examples/project.yml
+++ b/Examples/project.yml
@@ -49,3 +49,23 @@ targets:
         TARGETED_DEVICE_FAMILY: "1,2"
     dependencies:
       - package: Pagination
+  SwiftUIExample:
+    type: application
+    platform: iOS
+    sources:
+      - SwiftUI
+      - Shared
+    settings:
+      base:
+        CODE_SIGN_IDENTITY: ""
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        IPHONEOS_DEPLOYMENT_TARGET: "17.0"
+        MACOSX_DEPLOYMENT_TARGET: "14.0"
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.SwiftUIExample
+        SDKROOT: auto
+        SUPPORTED_PLATFORMS: iphonesimulator iphoneos macosx
+        TARGETED_DEVICE_FAMILY: "1,2"
+    dependencies:
+      - package: Pagination

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ DERIVED_DATA_PATH = ~/.derivedData
 EXAMPLES_PROJECT = Examples/Examples.xcodeproj
 
 .PHONY: default test-ios test-macos format examples \
-        build-examples-ios build-examples-macos build-objc-ios
+        build-examples-ios build-examples-macos build-objc-ios \
+        build-swiftui-ios build-swiftui-macos
 
 default: test-ios
 
@@ -47,6 +48,20 @@ build-objc-ios: examples
 		-project $(EXAMPLES_PROJECT) \
 		-scheme Objc \
 		-destination platform="$(PLATFORM_IOS)" \
+		-derivedDataPath $(DERIVED_DATA_PATH)
+
+build-swiftui-ios: examples
+	xcodebuild build \
+		-project $(EXAMPLES_PROJECT) \
+		-scheme SwiftUIExample \
+		-destination platform="$(PLATFORM_IOS)" \
+		-derivedDataPath $(DERIVED_DATA_PATH)
+
+build-swiftui-macos: examples
+	xcodebuild build \
+		-project $(EXAMPLES_PROJECT) \
+		-scheme SwiftUIExample \
+		-destination 'platform=macOS' \
 		-derivedDataPath $(DERIVED_DATA_PATH)
 
 define udid_for

--- a/Sources/Pagination+SwiftUI.swift
+++ b/Sources/Pagination+SwiftUI.swift
@@ -1,0 +1,296 @@
+#if canImport(SwiftUI)
+  import SwiftUI
+
+  #if canImport(UIKit)
+    import UIKit
+  #elseif canImport(AppKit)
+    import AppKit
+  #endif
+
+  // MARK: - Environment values
+
+  private struct PaginationDirectionKey: EnvironmentKey {
+    static let defaultValue: PaginationDirection = .vertical
+  }
+
+  private struct PaginationLeadingScreensKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 2.0
+  }
+
+  private struct PaginationEnabledKey: EnvironmentKey {
+    static let defaultValue: Bool = true
+  }
+
+  extension EnvironmentValues {
+    public var paginationDirection: PaginationDirection {
+      get { self[PaginationDirectionKey.self] }
+      set { self[PaginationDirectionKey.self] = newValue }
+    }
+
+    public var paginationLeadingScreens: CGFloat {
+      get { self[PaginationLeadingScreensKey.self] }
+      set { self[PaginationLeadingScreensKey.self] = newValue }
+    }
+
+    public var paginationEnabled: Bool {
+      get { self[PaginationEnabledKey.self] }
+      set { self[PaginationEnabledKey.self] = newValue }
+    }
+  }
+
+  // MARK: - Public view modifiers
+
+  extension View {
+    /// Sets the scroll direction monitored by any `.pagination` modifier in this subtree.
+    public func paginationDirection(_ direction: PaginationDirection) -> some View {
+      environment(\.paginationDirection, direction)
+    }
+
+    /// Sets the leading-screens prefetch threshold for any `.pagination` modifier in this
+    /// subtree. Defaults to `2.0`; `0` disables prefetching.
+    public func paginationLeadingScreens(_ screens: CGFloat) -> some View {
+      environment(\.paginationLeadingScreens, screens)
+    }
+
+    /// Enables or disables any `.pagination` modifier in this subtree.
+    public func paginationEnabled(_ enabled: Bool) -> some View {
+      environment(\.paginationEnabled, enabled)
+    }
+
+    /// Attaches pagination prefetching to the nearest enclosing scroll view.
+    ///
+    /// The `state` binding mirrors the pagination lifecycle: `.started` just before
+    /// `action` runs, `.completed` after it returns, `.failed` if it throws. Configuration
+    /// (direction, leading screens, enabled) is read from the environment — set it with
+    /// `.paginationDirection(_:)`, `.paginationLeadingScreens(_:)`, `.paginationEnabled(_:)`
+    /// applied to any ancestor.
+    ///
+    /// - Parameters:
+    ///   - state: Binding that receives state transitions as they happen.
+    ///   - action: Async throwing closure that performs the next-page fetch.
+    public func pagination(
+      state: Binding<PaginationState?>,
+      action: @escaping @MainActor @Sendable () async throws -> Void
+    ) -> some View {
+      modifier(PaginationViewModifier(state: state, action: action))
+    }
+  }
+
+  // MARK: - ViewModifier
+
+  private struct PaginationViewModifier: ViewModifier {
+    @Environment(\.paginationDirection) private var direction
+    @Environment(\.paginationLeadingScreens) private var leadingScreens
+    @Environment(\.paginationEnabled) private var isEnabled
+
+    @Binding var state: PaginationState?
+    let action: @MainActor @Sendable () async throws -> Void
+
+    func body(content: Content) -> some View {
+      content.background(
+        PaginationBridge(
+          state: $state,
+          action: action,
+          direction: direction,
+          leadingScreens: leadingScreens,
+          isEnabled: isEnabled
+        )
+        .frame(width: 0, height: 0)
+      )
+    }
+  }
+
+  // MARK: - Platform bridge
+
+  #if canImport(UIKit)
+
+    private struct PaginationBridge: UIViewRepresentable {
+      @Binding var state: PaginationState?
+      let action: @MainActor @Sendable () async throws -> Void
+      let direction: PaginationDirection
+      let leadingScreens: CGFloat
+      let isEnabled: Bool
+
+      func makeCoordinator() -> PaginationCoordinator {
+        PaginationCoordinator()
+      }
+
+      func makeUIView(context: Context) -> PaginationBridgeView {
+        let view = PaginationBridgeView()
+        view.coordinator = context.coordinator
+        return view
+      }
+
+      func updateUIView(_ uiView: PaginationBridgeView, context: Context) {
+        let coordinator = context.coordinator
+        coordinator.action = action
+        let binding = $state
+        coordinator.stateSetter = { binding.wrappedValue = $0 }
+        coordinator.direction = direction
+        coordinator.leadingScreens = leadingScreens
+        coordinator.isEnabled = isEnabled
+        uiView.resolve()
+      }
+    }
+
+    final class PaginationBridgeView: UIView {
+      weak var coordinator: PaginationCoordinator?
+      private weak var attachedScrollView: UIScrollView?
+
+      init() {
+        super.init(frame: .zero)
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+      }
+
+      required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+      }
+
+      override func didMoveToWindow() {
+        super.didMoveToWindow()
+        resolve()
+      }
+
+      func resolve() {
+        let scrollView = findEnclosingScrollView()
+        if scrollView !== attachedScrollView {
+          attachedScrollView = scrollView
+          coordinator?.attach(to: scrollView)
+        }
+        coordinator?.applyConfiguration()
+      }
+
+      private func findEnclosingScrollView() -> UIScrollView? {
+        var ancestor: UIView? = superview
+        while let current = ancestor {
+          if let scrollView = current as? UIScrollView { return scrollView }
+          if let scrollView = searchSubtree(of: current, excluding: self) { return scrollView }
+          ancestor = current.superview
+        }
+        return nil
+      }
+
+      private func searchSubtree(of view: UIView, excluding exclude: UIView) -> UIScrollView? {
+        for subview in view.subviews where subview !== exclude {
+          if let scrollView = subview as? UIScrollView { return scrollView }
+          if let scrollView = searchSubtree(of: subview, excluding: exclude) { return scrollView }
+        }
+        return nil
+      }
+    }
+
+  #elseif canImport(AppKit)
+
+    private struct PaginationBridge: NSViewRepresentable {
+      @Binding var state: PaginationState?
+      let action: @MainActor @Sendable () async throws -> Void
+      let direction: PaginationDirection
+      let leadingScreens: CGFloat
+      let isEnabled: Bool
+
+      func makeCoordinator() -> PaginationCoordinator {
+        PaginationCoordinator()
+      }
+
+      func makeNSView(context: Context) -> PaginationBridgeView {
+        let view = PaginationBridgeView()
+        view.coordinator = context.coordinator
+        return view
+      }
+
+      func updateNSView(_ nsView: PaginationBridgeView, context: Context) {
+        let coordinator = context.coordinator
+        coordinator.action = action
+        let binding = $state
+        coordinator.stateSetter = { binding.wrappedValue = $0 }
+        coordinator.direction = direction
+        coordinator.leadingScreens = leadingScreens
+        coordinator.isEnabled = isEnabled
+        nsView.resolve()
+      }
+    }
+
+    final class PaginationBridgeView: NSView {
+      weak var coordinator: PaginationCoordinator?
+      private weak var attachedScrollView: NSScrollView?
+
+      override var isFlipped: Bool { true }
+
+      override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        resolve()
+      }
+
+      func resolve() {
+        let scrollView = findEnclosingScrollView()
+        if scrollView !== attachedScrollView {
+          attachedScrollView = scrollView
+          coordinator?.attach(to: scrollView)
+        }
+        coordinator?.applyConfiguration()
+      }
+
+      private func findEnclosingScrollView() -> NSScrollView? {
+        var ancestor: NSView? = superview
+        while let current = ancestor {
+          if let scrollView = current as? NSScrollView { return scrollView }
+          if let scrollView = searchSubtree(of: current, excluding: self) { return scrollView }
+          ancestor = current.superview
+        }
+        return nil
+      }
+
+      private func searchSubtree(of view: NSView, excluding exclude: NSView) -> NSScrollView? {
+        for subview in view.subviews where subview !== exclude {
+          if let scrollView = subview as? NSScrollView { return scrollView }
+          if let scrollView = searchSubtree(of: subview, excluding: exclude) { return scrollView }
+        }
+        return nil
+      }
+    }
+
+  #endif
+
+  // MARK: - Coordinator
+
+  @MainActor
+  final class PaginationCoordinator: NSObject, @preconcurrency PaginationDelegate {
+    var action: (@MainActor @Sendable () async throws -> Void)?
+    var stateSetter: ((PaginationState?) -> Void)?
+    var direction: PaginationDirection = .vertical
+    var leadingScreens: CGFloat = 2.0
+    var isEnabled: Bool = true
+
+    private weak var scrollView: ScrollView?
+
+    func attach(to scrollView: ScrollView?) {
+      self.scrollView = scrollView
+      scrollView?.pagination.delegate = self
+    }
+
+    func applyConfiguration() {
+      guard let scrollView else { return }
+      scrollView.pagination.direction = direction
+      scrollView.pagination.leadingScreensForPrefetching = leadingScreens
+      scrollView.pagination.isEnabled = isEnabled
+    }
+
+    func pagination(_ pagination: Pagination, prefetchNextPageWith context: PaginationContext) {
+      guard let action else { return }
+      context.update(state: .started)
+      stateSetter?(.started)
+      Task { @MainActor in
+        do {
+          try await action()
+          context.update(state: .completed)
+          self.stateSetter?(.completed)
+        } catch {
+          context.update(state: .failed)
+          self.stateSetter?(.failed)
+        }
+      }
+    }
+  }
+
+#endif

--- a/Sources/Pagination.swift
+++ b/Sources/Pagination.swift
@@ -111,6 +111,13 @@
     private(set) var observation: (any NSObjectProtocol)?
   #endif
 
+  /// The content size at the moment the last prefetch was triggered, or `nil` before the
+  /// first trigger. Used to suppress redundant prefetch calls that can fire between
+  /// `context.update(state: .completed)` and the scroll view's content size being updated
+  /// with the newly-loaded data — during that window `shouldPrefetchNextPage` would otherwise
+  /// still see a remaining distance below the threshold and re-invoke the delegate.
+  private var contentSizeAtLastFetch: CGSize?
+
   /// Initializes a new instance of `Pagination` with default settings.
   public override init() {
     self.isEnabled = true
@@ -228,6 +235,13 @@
       let flipsHorizontallyInOppositeLayoutDirection = false
     #endif
 
+    // Suppress duplicate triggers while the scroll view's content size is still
+    // reflecting data from the previous fetch. Optional handling keeps the first
+    // call (empty or small content) from being suppressed.
+    if let last = contentSizeAtLastFetch, scrollViewContentSize == last {
+      return
+    }
+
     if shouldPrefetchNextPage(
       context: context,
       scrollDirection: scrollDirection,
@@ -240,6 +254,7 @@
       shouldRenderRTLLayout: shouldRenderRTLLayout,
       flipsHorizontallyInOppositeLayoutDirection: flipsHorizontallyInOppositeLayoutDirection)
     {
+      contentSizeAtLastFetch = scrollViewContentSize
       delegate.pagination(self, prefetchNextPageWith: context)
     }
   }

--- a/Sources/PaginationDirection.swift
+++ b/Sources/PaginationDirection.swift
@@ -1,5 +1,5 @@
 /// Represents the pagination direction.
-@objc public enum PaginationDirection: Int {
+@objc public enum PaginationDirection: Int, Sendable {
   /// The vertical pagination direction.
   case vertical
   /// The horizontal pagination direction.


### PR DESCRIPTION
## Summary

Adds a SwiftUI surface for the `Pagination` library, plus two small library refinements from an older stash.

**SwiftUI API** ([\`Sources/Pagination+SwiftUI.swift\`](Sources/Pagination+SwiftUI.swift)) — new, guarded by \`#if canImport(SwiftUI)\`:

- Environment-driven configuration: \`.paginationDirection(_:)\`, \`.paginationLeadingScreens(_:)\`, \`.paginationEnabled(_:)\` propagate through the environment, so callers can set pagination config on any ancestor and have it applied to the \`.pagination\` modifier below.
- \`.pagination(state: Binding<PaginationState?>, action: @escaping @MainActor @Sendable () async throws -> Void)\` — attaches to the nearest enclosing scroll view via introspection of the underlying \`UIScrollView\`/\`NSScrollView\`. The \`state\` binding receives \`.started\` just before \`action\` runs, \`.completed\` when it returns, \`.failed\` if it throws — no manual \`context.update(state:)\` calls at the call site.
- Internal \`PaginationCoordinator\` bridges the existing \`PaginationDelegate\` protocol onto the async closure.

Usage:

```swift
@State private var state: PaginationState?

ScrollView {
  LazyVStack { ForEach(items) { ... } }
}
.paginationDirection(.vertical)
.paginationEnabled(hasMorePages)
.pagination(state: \$state) {
  try await viewModel.fetchNextPage()
}
```

**Library refinements** (ported from the \`feature/macos-support\` stash with path fixes for the flattened layout):

- [\`Sources/Pagination.swift\`](Sources/Pagination.swift) — adds \`contentSizeAtLastFetch: CGSize?\` to suppress duplicate prefetch callbacks during the window between \`context.update(state: .completed)\` and the scroll view's content size being updated with newly-loaded data. First-call handling via Optional so empty / small-content initial prefetches still fire.
- [\`Sources/PaginationDirection.swift\`](Sources/PaginationDirection.swift) — adds \`Sendable\` conformance.

The scroll-view introspection walks up the superview chain from a zero-size \`UIView\`/\`NSView\` placed via \`.background(...)\`, and at each ancestor also searches sibling subtrees. Known caveat: SwiftUI internals aren't guaranteed stable across OS versions; this uses no third-party introspection library.

## Test plan

- [x] \`make test-ios\` — 65 tests pass
- [x] \`make test-macos\` — 63 tests pass
- [x] Manual: build a SwiftUI \`ScrollView\` + \`.pagination\` sample on iOS and verify the action closure fires as the list approaches the bottom, and the state binding transitions through \`.started\` → \`.completed\`
- [x] Manual: same on macOS with \`ScrollView\` and \`List\`
- [x] Follow-up: add a SwiftUI example target to \`Examples/\`